### PR TITLE
check_postgres --action=sequence errors when checking sequences in the temp namespace

### DIFF
--- a/check_postgres.pl
+++ b/check_postgres.pl
@@ -7015,6 +7015,7 @@ FROM (
  JOIN pg_namespace nsp ON nsp.oid = relnamespace
  WHERE relkind = 'S'
 ) AS seqs
+WHERE nspname !~ '^pg_temp.*'
 ORDER BY nspname, seqname, typname
 };
 


### PR DESCRIPTION
See the bug report at: http://bucardo.org/bugzilla/show_bug.cgi?id=97

Sequences in the temporary namespace cannot be checked, because other sessions cannot access them. So, ignore them. This may not be the best patch, but if you have other ideas/suggestions let me know.