### PR TITLE
Ignore sequences in the temporary namespace

### DIFF
--- a/check_postgres.pl
+++ b/check_postgres.pl
@@ -7148,6 +7148,7 @@ FROM (
  JOIN pg_namespace nsp ON nsp.oid = relnamespace
  WHERE relkind = 'S'
 ) AS seqs
+WHERE nspname !~ '^pg_temp.*'
 ORDER BY nspname, seqname, typname
 };
     ## use critic


### PR DESCRIPTION
This is again my patch to ignore temporary sequences when doing sequence checks. The values in them are not accessible. This is in reference to: http://bucardo.org/bugzilla/show_bug.cgi?id=97
