### PR TITLE
Fix the check_bloat SQL to take inherited and non-analyzed attributes into account.

### DIFF
--- a/check_postgres.pl.bak
+++ b/check_postgres.pl.bak
@@ -32,7 +32,7 @@ $Data::Dumper::Useqq = 1;
 
 binmode STDOUT, ':utf8';
 
-our $VERSION = '2.20.1';
+our $VERSION = '2.20.0';
 
 use vars qw/ %opt $PGBINDIR $PSQL $res $COM $SQL $db /;
 


### PR DESCRIPTION
Currently, if columns are not analyzed (not in pg_stats), they are not
taken into account, leading to a huge overestimation of the bloat.

Additionally, inherited columns are not included.

This patch fixes that by assuming 2048 average width for columns that are not analyzed.
