### PR TITLE
Fix userclause handling in check_txn_idle

### DIFF
--- a/check_postgres.pl
+++ b/check_postgres.pl
@@ -7550,8 +7550,8 @@ sub check_txn_idle {
 
     ## Craft an alternate version for new servers which do not have procpid and current_query is split
     ($SQL3 = $SQL) =~ s/procpid/pid/g;
-    $SQL3 =~ s/current_query ~ '\^<'/state = 'idle in transaction' OR state IS NULL/;
-    $SQL3 =~ s/current_query NOT LIKE '<IDLE>%'/state NOT LIKE 'idle%' OR state IS NULL/; # query_time
+    $SQL3 =~ s/current_query ~ '\^<'/(state = 'idle in transaction' OR state IS NULL)/;
+    $SQL3 =~ s/current_query NOT LIKE '<IDLE>%'/(state NOT LIKE 'idle%' OR state IS NULL)/; # query_time
     $SQL3 =~ s/current_query/query/g;
     $SQL3 =~ s/'' AS state/state AS state/;
 


### PR DESCRIPTION
For databases > Postgrs 9.1, irrelevant records are discarded
with two ORed conditions. This makes the optional userclause
associate with the right hand side of the condition. The expression
needs to be grouped to get the desired effect regardless of the
evaluation of the previous condition.
