### PR TITLE
Allow the --reverse flag to invert string comparisons in custom queries

### DIFF
--- a/check_postgres.pl
+++ b/check_postgres.pl
@@ -4084,7 +4084,7 @@ sub check_custom_query {
                 return;
             }
             if (length $critical) {
-                if (($valtype eq 'string' and $result eq $critical)
+                if (($valtype eq 'string' and $reverse ? $result ne $critical : $result eq $critical)
                     or
                     ($valtype ne 'string' and $reverse ? $result <= $critical : $result >= $critical)) { ## covers integer, time, size
                     add_critical "$result";
@@ -4093,7 +4093,7 @@ sub check_custom_query {
             }
 
             if (length $warning and ! $gotmatch) {
-                if (($valtype eq 'string' and $result eq $warning)
+                if (($valtype eq 'string' and $reverse ? $result ne $warning : $result eq $warning)
                     or
                     ($valtype ne 'string' and length $result and $reverse ? $result <= $warning : $result >= $warning)) {
                     add_warning "$result";


### PR DESCRIPTION
currently, a custom query can signal warning or critical when it matches a string

--query='SELECT status as result FROM table' --valtype=string -c "failure"

I'd like to be able to invert that and signal when it fails to match

--query='SELECT status as result FROM table' --valtype=string --reverse -c "OK"
