### PR TITLE
Don't swallow space before the -c flag when reporting errors

### DIFF
--- a/check_postgres.pl
+++ b/check_postgres.pl
@@ -2483,7 +2483,7 @@ sub run_command {
                     warn "Action:           $action\n";
                     warn "Calling line:     $cline\n";
                     warn "Output:           $line\n";
-                    $args =~ s/ -c (.+)/-c "$1"/s;
+                    $args =~ s/ -c (.+)/ -c "$1"/s;
                     warn "Command:          $PSQL $args\n";
                     ## Last thing is to see if we can grab the PG version
                     if (! $opt{stop_looping}) {


### PR DESCRIPTION
When reporting an error, it was reporting -x-c with no space between them.
