### PR TITLE
Fix documentation for hot_standby_delay

### DIFF
--- a/TODO
+++ b/TODO
@@ -2,8 +2,6 @@ Quick list of outstanding items / bugs / feature requests for CP:
 
 NOTE: All bugzilla items are now on github
 
-* Fix up references to dbhost2 and the like, or make them work again for backwards compatibility.
-
 * The same_schema action does not check indexes. See bugzilla #54
 
 * Perform automatic creation of views and function to allow all actions to be run

--- a/check_postgres.pl
+++ b/check_postgres.pl
@@ -8812,15 +8812,14 @@ and the name of the database on the fourth line.
 =head2 B<hot_standby_delay>
 
 (C<symlink: check_hot_standby_delay>) Checks the streaming replication lag by computing the delta 
-between the xlog position of a master server and the one of the slaves connected to it. The slave_
-server must be in hot_standby (e.g. read only) mode, therefore the minimum version to use this_
-action is Postgres 9.0. The I<--warning> and I<--critical> options are the delta between xlog 
-location. These values should match the volume of transactions needed to have the streaming 
-replication disconnect from the master because of too much lag.
+between the current xlog position of a master server and the replay location of a slave connected
+to it. The slave server must be in hot_standby (e.g. read only) mode, therefore the minimum version to use
+this action is Postgres 9.0. The I<--warning> and I<--critical> options are the delta between the xlog
+locations. Since these values are byte offsets in the WAL they should match the expected transaction volume
+of your application to prevent false postives or negatives.
 
-You must provide information on how to reach the second database by a connection 
-parameter ending in the number 2, such as "--dbport2=5543". If if it not given, 
-the action fails.
+The first "--dbname", "--host", and "--port", etc. options are considered the
+master; the second belongs to the slave.
 
 =head2 B<index_size>
 


### PR DESCRIPTION
Drop todo entry while we're at it.

The commit from april third seems to be already merged, that's a stray entry from an unclosed pull request.
