### PR TITLE
Multi-slave support for replicate_row.

### DIFF
--- a/check_postgres.pl
+++ b/check_postgres.pl
@@ -6172,16 +6172,13 @@ sub check_replicate_row {
     }
     my $value1 = $info1->{db}[0]{slurp}[0]{c} || '';
 
-    my $info2 = run_command($select, { dbnumber => 2 });
-    my $slave = 0;
-    for my $d (@{$info2->{db}}) {
-        $slave++;
+    my $numslaves = @{$info1->{db}} - 1;
+    foreach my $d ( @{$info1->{db}}[1 .. $numslaves] ) {
         my $value2 = $d->{slurp}[0]{c} || '';
         if ($value1 ne $value2) {
             ndie msg('rep-notsame');
-        }
+        }     
     }
-    my $numslaves = $slave;
     if ($numslaves < 1) {
         ndie msg('rep-noslaves');
     }
@@ -6222,12 +6219,12 @@ sub check_replicate_row {
     my %slave;
     my $time = 0;
     LOOP: {
-        $info2 = run_command($select, { dbnumber => 2 } );
+        my $info2 = run_command($select);
         ## Reset for final output
         $db = $sourcedb;
 
-        $slave = 0;
-        for my $d (@{$info2->{db}}) {
+        my $slave = 0;
+        for my $d (@{$info2->{db}}[1 .. $numslaves]) {
             $slave++;
             next if exists $slave{$slave};
             my $value2 = $d->{slurp}[0]{c};


### PR DESCRIPTION
check_replicate_row() seems to only check the first slave in the host list when verifying that the row is consistent on all machines, and when verifying when the row update is replicated to slaves.  The code is there to handle multiple slaves, it just doesn't appear to be getting a comprehensive list back from run_command().

I just made a couple of small tweaks in my fork that seem to the trick.  I wanted to include tests to illustrate the problem, but augmenting the test suite required changes more extensive than I was comfortable with making.  Trying not to step on too many toes here; I'm just very interested in using this as a monitoring solution.
