### PR TITLE
Don't fail when query contains 'disabled' word

### DIFF
--- a/check_postgres.pl
+++ b/check_postgres.pl
@@ -7651,7 +7651,7 @@ sub check_txn_idle {
         }
 
         ## Return unknown if stats_command_string / track_activities is off
-        if ($cq =~ /disabled/o or $cq =~ /<command string not enabled>/) {
+        if ($st =~ /disabled/o or $cq =~ /<command string not enabled>/) {
             add_unknown msg('psa-disabled');
             return;
         }


### PR DESCRIPTION
If a query contains the disabled word (.e.g. select 1 as disabled) "check_postgres.pl --action txn_idle" exits with

```UNKNOWN: No queries - is stats_command_string or track_activities off?```

If you set track_activities to off, the status field contains 'disabled' (at least on 9.3)