### PR TITLE
Correct extra space in perfdata

### DIFF
--- a/check_postgres.pl
+++ b/check_postgres.pl
@@ -4857,7 +4857,7 @@ sub check_hot_standby_delay {
         {one => $rep_delta, two => $rec_delta, three => $time_delta} :
         {one => $rep_delta, two => $rec_delta});
 
-    $db->{perf} = sprintf ' %s=%s;%s;%s ',
+    $db->{perf} = sprintf ' %s=%s;%s;%s',
         perfname(msg('hs-replay-delay')), $rep_delta, $warning, $critical;
     $db->{perf} .= sprintf ' %s=%s;%s;%s',
         perfname(msg('hs-receive-delay')), $rec_delta, $warning, $critical;


### PR DESCRIPTION
The extra space result in two spaces between the metrics and its incorrectly parse by centreon.