### PR TITLE
Fixes #32: Table/Relation Size don't take into account TOAST'd pages

### DIFF
--- a/check_postgres.pl
+++ b/check_postgres.pl
@@ -6031,8 +6031,8 @@ sub check_relation_size {
     my ($warning, $critical) = validate_range({type => 'size'});
 
     $SQL = sprintf q{
-SELECT pg_relation_size(c.oid) AS rsize,
-  pg_size_pretty(pg_relation_size(c.oid)) AS psize,
+SELECT pg_table_size(c.oid) AS rsize,
+  pg_size_pretty(pg_table_size(c.oid)) AS psize,
   relkind, relname, nspname
 FROM pg_class c, pg_namespace n WHERE (relkind = %s) AND n.oid = c.relnamespace
 },


### PR DESCRIPTION
This PR fixes https://github.com/bucardo/check_postgres/issues/32 by replacing `pg_relation_size` with `pg_table_size`.

See http://www.postgresql.org/docs/9.4/static/functions-admin.html#FUNCTIONS-ADMIN-DBOBJECT for more details.