### PR TITLE
Recent changes to check_sequence breaks checking of many sequences

### DIFF
--- a/check_postgres.pl
+++ b/check_postgres.pl
@@ -6153,7 +6153,7 @@ sub check_replicate_row {
     my ($table,$pk,$id,$col,$val1,$val2) = (@repinfo);
 
     ## Quote everything, just to be safe (e.g. columns named 'desc')
-    $table = qq{"$table"};
+    $table =~ s/([^\.]+)/\"$1\"/g;
     $pk    = qq{"$pk"};
     $col   = qq{"$col"};
 

--- a/check_postgres.pl
+++ b/check_postgres.pl
@@ -6149,7 +6149,7 @@ sub check_replicate_row {
     my ($table,$pk,$id,$col,$val1,$val2) = (@repinfo);
 
     ## Quote everything, just to be safe (e.g. columns named 'desc')
-    $table =~ s/([^\.]+)/\"$1\"/g;
+    $table = qq{"$table"};
     $pk    = qq{"$pk"};
     $col   = qq{"$col"};
 

--- a/check_postgres.pl
+++ b/check_postgres.pl
@@ -6117,7 +6117,7 @@ sub check_replicate_row {
     my ($table,$pk,$id,$col,$val1,$val2) = (@repinfo);
 
     ## Quote everything, just to be safe (e.g. columns named 'desc')
-    $table = qq{"$table"};
+    $table =~ s/([^\.]+)/\"$1\"/g;
     $pk    = qq{"$pk"};
     $col   = qq{"$col"};
 


### PR DESCRIPTION
Changes in commit f069af5d60587c93efd7c190706f08b81d6fad1f cause sequence checks to fail when a database contains a large quantity of sequences.  This is because the monster UNION ALL query constructed can overrun the maximum argument size (at least on my debian/netbsd platforms).

I have attempted to resolve this without losing the benefits of the UNION ALL by "chunking" the statement into chunks of no more than 200 sequences at a time.

Also, run_command used to accept a "target = dbinfo" argument as supplied by check_sequence, but this seems to have been overlooked when targetdb was refactored.  This caused sequences form each database to be incorrectly checked against all database names supplied to check_sequence.  I have also attempted to resolve this with another check in run_command where dbnumber is checked.