### PR TITLE
Call psql with option -X

### DIFF
--- a/check_postgres.pl
+++ b/check_postgres.pl
@@ -2524,7 +2524,7 @@ sub run_command {
         ## Store this target in the global target list
         push @{$info->{db}}, $db;
 
-        my @args = ('-q', '-t');
+        my @args = ('-X', '-q', '-t');
         if (defined $db->{dbservice} and length $db->{dbservice}) { ## XX Check for simple names
             $db->{pname} = "service=$db->{dbservice}";
             $ENV{PGSERVICE} = $db->{dbservice};


### PR DESCRIPTION
Starting in PostgreSQL 9.6, `psql -c` no longer implies `-X`, so it has to be added explicitly in order to avoid customizations in `.psqlrc` interfering with the output parsing.