### PR TITLE
Fix for changes to psql in 9.6

### DIFF
--- a/check_postgres.pl
+++ b/check_postgres.pl
@@ -2594,7 +2594,7 @@ sub run_command {
         local $SIG{ALRM} = sub { die 'Timed out' };
         alarm 0;
 
-        push @args, '-c', $string;
+        push @args, '-X', '-c', $string;
 
         $VERBOSE >= 3 and warn Dumper \@args;
 

--- a/t/CP_Testing.pm
+++ b/t/CP_Testing.pm
@@ -225,37 +225,37 @@ sub test_database_handle {
             my $COM;
 
             $SQL = q{SELECT * FROM pg_database WHERE datname = 'postgres'};
-            my $res = qx{psql -Ax -qt -d template1 -q -h "$host" -c "$SQL"};
+            my $res = qx{psql -Ax -qt -d template1 -q -h "$host" -X -c "$SQL"};
             if ($res !~ /postgres/) {
-                $COM = qq{psql -d template1 -q -h "$host" -c "CREATE DATABASE postgres"};
+                $COM = qq{psql -d template1 -q -h "$host" -X -c "CREATE DATABASE postgres"};
                 system $COM;
             }
 
             my $newuser = $self->{testuser};
             $SQL = qq{SELECT * FROM pg_user WHERE usename = '$newuser'};
-            $res = qx{psql -Ax -qt -d template1 -q -h "$host" -c "$SQL"};
+            $res = qx{psql -Ax -qt -d template1 -q -h "$host" -X -c "$SQL"};
             if ($res !~ /$newuser/) {
-                $COM = qq{psql -d template1 -q -h "$host" -c "CREATE USER $newuser"};
+                $COM = qq{psql -d template1 -q -h "$host" -X -c "CREATE USER $newuser"};
                 system $COM;
                 $SQL = qq{UPDATE pg_shadow SET usesuper='t' WHERE usename = '$newuser'};
-                $COM = qq{psql -d postgres -q -h "$host" -c "$SQL"};
+                $COM = qq{psql -d postgres -q -h "$host" -X -c "$SQL"};
                 system $COM;
             }
 
             $newuser = $self->{testuser2};
             $SQL = qq{SELECT * FROM pg_user WHERE usename = '$newuser'};
-            $res = qx{psql -Ax -qt -d template1 -q -h "$host" -c "$SQL"};
+            $res = qx{psql -Ax -qt -d template1 -q -h "$host" -X -c "$SQL"};
             if ($res !~ /$newuser/) {
-                $COM = qq{psql -d template1 -q -h "$host" -c "CREATE USER $newuser"};
+                $COM = qq{psql -d template1 -q -h "$host" -X -c "CREATE USER $newuser"};
                 system $COM;
                 $SQL = qq{UPDATE pg_shadow SET usesuper='t' WHERE usename = '$newuser'};
-                $COM = qq{psql -d postgres -q -h "$host" -c "$SQL"};
+                $COM = qq{psql -d postgres -q -h "$host" -X -c "$SQL"};
                 system $COM;
             }
 
             for my $lang (qw/plpgsql plperlu/) {
                 $SQL = qq{SELECT * FROM pg_language WHERE lanname = '$lang'};
-                $res = qx{psql -Ax -qt -d postgres -q -h "$host" -c "$SQL"};
+                $res = qx{psql -Ax -qt -d postgres -q -h "$host" -X -c "$SQL"};
                 if ($res !~ /$lang/) {
                     my $createlang = $ENV{PGBINDIR} ? "$ENV{PGBINDIR}/createlang" : 'createlang';
                     $COM = qq{$createlang -d postgres -h "$host" $lang};


### PR DESCRIPTION
Before 9.6, -c implied -X for psql.  In 9.6, it no longer
does.  Make -X explicit where -c is used.  

With this, the current 9.6 HEAD passes "make test".

Tested back to 9.1 with "make test" to ensure compatibility.