### PR TITLE
Same schema logical fixes

### DIFF
--- a/check_postgres.pl
+++ b/check_postgres.pl
@@ -8102,7 +8102,7 @@ sub check_txn_idle {
         $whodunit = sprintf q{%s:%s %s:%s %s:%s%s%s %s:%s},
             msg('PID'), $maxr->{pid},
             msg('database'), $maxr->{datname},
-            msg('username'), $maxr->{rolname},
+            msg('username'), $maxr->{usename},
             $maxr->{client_addr} eq '' ? '' : (sprintf ' %s:%s', msg('address'), $maxr->{client_addr}),
             ($maxr->{client_port} eq '' or $maxr->{client_port} < 1)
                 ? '' : (sprintf ' %s:%s', msg('port'), $maxr->{client_port}),

--- a/check_postgres.pl
+++ b/check_postgres.pl
@@ -7260,7 +7260,7 @@ sub schema_item_exists {
             for my $name (sort keys %{ $itemhash->{$db1}{$item_class} }) {
 
                 ## Can exclude by 'filter' based regex
-                next if grep { $name eq $_ } @$exclude_regex;
+                next if grep { $name =~ $_ } @$exclude_regex;
 
                 if (! exists $itemhash->{$db2}{$item_class}{$name}) {
 
@@ -7336,7 +7336,7 @@ sub schema_item_differences {
             for my $name (sort keys %{ $itemhash->{$db1}{$item_class} }) {
 
                 ## Can exclude by 'filter' based regex
-                next if grep { $name eq $_ } @$exclude_regex;
+                next if grep { $name =~ $_ } @$exclude_regex;
 
                 ## This case has already been handled:
                 next if ! exists $itemhash->{$db2}{$item_class}{$name};

--- a/check_postgres.pl
+++ b/check_postgres.pl
@@ -6756,7 +6756,7 @@ sub check_same_schema {
                         indexprs,indcheckxmin,reltablespace,
                         indkey',                                  ''          ],
         [trigger    => 'tgqual,tgconstraint',                     ''          ],
-        [constraint => 'conbin,conindid,conkey,confkey
+        [constraint => 'conbin,conindid,conkey,confkey,
                         confmatchtype',                           ''          ],
         [column     => 'atttypid,attnum,attbyval,attndims',       ''          ],
     );

--- a/check_postgres.pl
+++ b/check_postgres.pl
@@ -1066,7 +1066,7 @@ WHERE c.relkind = 'i'},
     },
     operator => {
         SQL       => q{
-SELECT o.*, o.oid, n.nspname||'.'||o.oprname AS name, quote_ident(o.oprname) AS safename,
+SELECT o.*, o.oid, n.nspname||'.'||o.oprname||' ('||COALESCE(t2.typname,'NONE')||','||COALESCE(t3.typname,'NONE')||')' AS name, quote_ident(o.oprname) AS safename,
   rolname AS owner, n.nspname AS schema,
   t1.typname AS resultname,
   t2.typname AS leftname, t3.typname AS rightname,

--- a/check_postgres.pl
+++ b/check_postgres.pl
@@ -1102,7 +1102,7 @@ JOIN pg_proc p ON (p.oid = t.tgfoid)
 JOIN pg_namespace n3 ON (n3.oid = p.pronamespace)
 LEFT JOIN pg_class c2 ON (c2.oid = t.tgconstrrelid)
 LEFT JOIN pg_namespace n2 ON (n2.oid = c2.relnamespace)
-WHERE t.tgconstrrelid = 0 AND tgname !~ '^pg_'},
+WHERE t.tgconstrrelid = 0 AND t.tgconstrindid = 0 AND tgname !~ '^pg_'},
     },
     function => {
         SQL       => q{

--- a/check_postgres.pl
+++ b/check_postgres.pl
@@ -1119,7 +1119,7 @@ JOIN pg_namespace n ON (n.oid = p.pronamespace)},
         SQL       => q{
 SELECT c.*, c.oid, n.nspname||'.'||c1.relname||'.'||c.conname AS name, quote_ident(c.conname) AS safename,
  n.nspname AS schema, r.relname AS tname,
- pg_get_constraintdef(c.oid) AS constraintdef
+ pg_get_constraintdef(c.oid) AS constraintdef, translate(c.confmatchtype,'u','s') AS confmatchtype_compat
 FROM pg_constraint c
 JOIN pg_class c1 ON (c1.oid = c.conrelid)
 JOIN pg_namespace n ON (n.oid = c.connamespace)
@@ -6756,7 +6756,8 @@ sub check_same_schema {
                         indexprs,indcheckxmin,reltablespace,
                         indkey',                                  ''          ],
         [trigger    => 'tgqual,tgconstraint',                     ''          ],
-        [constraint => 'conbin,conindid,conkey,confkey',          ''          ],
+        [constraint => 'conbin,conindid,conkey,confkey
+                        confmatchtype',                           ''          ],
         [column     => 'atttypid,attnum,attbyval,attndims',       ''          ],
     );
 

--- a/t/02_same_schema.t
+++ b/t/02_same_schema.t
@@ -340,6 +340,7 @@ Sequence "wakko.yakko" does not exist on all databases:
 
 $t = qq{$S reports sequence differences};
 $dbh2->do(q{CREATE SEQUENCE wakko.yakko MINVALUE 10 MAXVALUE 100 INCREMENT BY 3});
+
 like ($cp1->run($connect2),
       qr{^$label CRITICAL.*Items not matched: 1 .*
 \s*Sequence "wakko.yakko":
@@ -493,7 +494,7 @@ like ($cp1->run($connect2),
 \s*"relhastriggers" is different:
 \s*Database 1: t
 \s*Database 2: f
-\s*Trigger "public.tigger" does not exist on all databases:
+\s*Trigger "public.piglet.tigger" does not exist on all databases:
 \s*Exists on:  1
 \s*Missing on: 2\s*$}s,
       $t);
@@ -509,7 +510,7 @@ $dbh2->do($SQL);
 
 like ($cp1->run($connect2),
       qr{^$label CRITICAL.*Items not matched: 1 .*
-\s*Trigger "public.tigger":
+\s*Trigger "public.piglet.tigger":
 \s*"procname" is different:
 \s*Database 1: bouncy
 \s*Database 2: trouncy\s*}s,
@@ -525,7 +526,7 @@ $dbh1->do($SQL);
 ## We leave out the details as the exact values are version-dependent
 like ($cp1->run($connect2),
       qr{^$label CRITICAL.*Items not matched: 1 .*
-\s*Trigger "public.tigger":
+\s*Trigger "public.piglet.tigger":
 \s*"tgenabled" is different:}s,
       $t);
 
@@ -559,7 +560,7 @@ like ($cp1->run($connect2),
 \s*"relchecks" is different:
 \s*Database 1: 1
 \s*Database 2: 0
-\s*Constraint "public.iscandar" does not exist on all databases:
+\s*Constraint "public.yamato.iscandar" does not exist on all databases:
 \s*Exists on:  1
 \s*Missing on: 2\s*$}s,
       $t);
@@ -568,11 +569,16 @@ $t = qq{$S reports constraint with different definitions};
 $dbh2->do(q{ALTER TABLE yamato ADD CONSTRAINT iscandar CHECK(nova > 256)});
 like ($cp1->run($connect2),
       qr{^$label CRITICAL.*Items not matched: 1 .*
-\s*Constraint "public.iscandar":
+\s*Constraint "public.yamato.iscandar":
 \s*"consrc" is different:
 \s*Database 1: \(nova > 0\)
-\s*Database 2: \(nova > 256\)\s*$}s,
+\s*Database 2: \(nova > 256\)
+\s*"constraintdef" is different:
+\s*Database 1: CHECK \(\(nova > 0\)\)
+\s*Database 2: CHECK \(\(nova > 256\)\)\s*$}s,
       $t);
+
+
 
 $t = qq{$S does not report constraint differences if the 'noconstraint' filter is given};
 like ($cp1->run("$connect3 --filter=noconstraint,notables"), qr{^$label OK}, $t);


### PR DESCRIPTION
This branch contains changes to check_same_schema mainly to assist when comparing schemas across logical replicas.
    * support checking across logical replicas by checking logical name/type/definition when comparing operators/indices/functions/triggers etc rather than oids
    * add '--assume-async' option to skip checking sequnece last_val on asyncronous replicas
    * stop picking up oid named deferrable unique constraint triggers in trigger check
    * correctly identify objects owned by group roles
    * allow constraint check to work across <= 9.2 and >= 9.3 (pg_constraint.confmatchtype = 'u' == 's')
    * include table name in key used to identify trigger and constraint checks to prevent false positives
    * --filter on regex (as per the manual) rather than equality