### PR TITLE
Fix "values are not the same" error in replicate_row when repinfo value is a '0'

### DIFF
--- a/check_postgres.pl
+++ b/check_postgres.pl
@@ -6442,11 +6442,11 @@ sub check_replicate_row {
     if (!defined $sourcedb) {
         ndie msg('rep-norow', "$table.$col");
     }
-    my $value1 = $info1->{db}[0]{slurp}[0]{c} || '';
+    my $value1 = (defined($info1->{db}[0]{slurp}[0]{c})?$info1->{db}[0]{slurp}[0]{c}:'');
 
     my $numslaves = @{$info1->{db}} - 1;
     for my $d ( @{$info1->{db}}[1 .. $numslaves] ) {
-        my $value2 = $d->{slurp}[0]{c} || '';
+        my $value2 = (defined($d->{slurp}[0]{c})?$d->{slurp}[0]{c}:'');
         if ($value1 ne $value2) {
             ndie msg('rep-notsame');
         }


### PR DESCRIPTION
When check_replicate_row tested for valid values before starting the check, if the actual value returned was 0 it would evaluate to false, resulting in the error:
	"Cannot test replication: values are not the same"

This is resolved by simply checking if the value is defined before assigning it's value a blank string instead.