### PR TITLE
Add "notablespace" option to same_schema

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -47,6 +47,11 @@ my @cleanfiles = (
     '/tmp/cptesting_socket3',
     '/tmp/cptesting_socket4',
     '/tmp/cptesting_socket5',
+	'test_tablespace_check_postgres/',
+	'test_tablespace_check_postgres2/',
+	'test_tablespace_check_postgres3/',
+	'test_tablespace_check_postgres4/',
+	'test_tablespace_check_postgres5/',
 );
 
 print "Configuring check_postgres $VERSION\n";

--- a/check_postgres.pl
+++ b/check_postgres.pl
@@ -6992,6 +6992,12 @@ sub check_same_schema {
                             next;
                         }
 
+                        ## Do not show tablespace differences if filtered out with "notablespace"
+                        if (($col eq 'tablespace' or $col eq 'reltablespace')
+                            and $opt{filtered}{notablespace}) {
+                            next;
+                        }
+
                         ## Do not show function body differences if filtered out with "nofuncbody"
                         ## Also skip if the equivalent 'dash' and 'empty'
                         if ($item eq 'function'
@@ -9843,6 +9849,8 @@ The filter option "nofuncbody" prevents comparison of the bodies of all
 functions.
 
 The filter option "noperm" prevents comparison of object permissions.
+
+The filter option "notablespace" prevents comparison of object tablespaces.
 
 To provide the second database, just append the differences to the first one 
 by a call to the appropriate connection argument. For example, to compare 

--- a/t/02_same_schema.t
+++ b/t/02_same_schema.t
@@ -6,7 +6,7 @@ use 5.006;
 use strict;
 use warnings;
 use Data::Dumper;
-use Test::More tests => 76;
+use Test::More tests => 78;
 use lib 't','.';
 use CP_Testing;
 
@@ -308,6 +308,20 @@ Table "public.berri":
 \s*Database 1: r/check_postgres_testing
 \s*Database 2: wd/check_postgres_testing\s*}s,
       $t);
+$dbh2->do(q{REVOKE UPDATE,DELETE ON TABLE berri FROM alternate_owner});
+$dbh1->do(q{REVOKE SELECT ON TABLE berri FROM alternate_owner});
+
+$t = qq{$S reports tablespace differences};
+$dbh1->do(q{ALTER TABLE berri SET TABLESPACE check_postgres});
+like ($cp1->run($connect2),
+      qr{^$label CRITICAL.*Items not matched: 1 .*
+Table "public.berri":
+\s*"reltablespace" is different:.*
+\s*"tablespace" is different:.*}s,
+      $t);
+
+$t = qq{$S does not report tablespace differences if the 'notablespace' filter is given};
+like ($cp1->run("$connect2 --filter=notablespace"), qr{^$label OK}, $t); 
 
 $t = qq{$S does not report table differences if the 'notable' filter is given};
 like ($cp1->run("$connect3 --filter=notable"), qr{^$label OK}, $t);


### PR DESCRIPTION
It's useful to be able to ignore tablespaces when otherwise identical databases are hosted on servers with different hardware capabilities.

This commit includes changes to CP_Testing.pm to create some tablespaces for the unit tests.