### PR TITLE
custom_query perfdata multi-row output improvements

### DIFF
--- a/check_postgres.pl
+++ b/check_postgres.pl
@@ -4398,9 +4398,13 @@ sub check_custom_query {
 
         my $goodrow = 0;
 
-        ## The other column tells it the name to use as the perfdata value
+        ## If there is a single row and at least 2 columns,
+        ##  the other column tells it the name to use as the perfdata value
+        ## If there are multiple rows and at least 2 columns,
+        ##   use the second column value as the perfdata name,
+        ##   use the result value as the perfdata value.
         my $perfname;
-
+        my $grandtotal = @{$db->{slurp}};
         for my $r (@{$db->{slurp}}) {
             my $result = $r->{result};
             if (! defined $perfname) {
@@ -4413,8 +4417,13 @@ sub check_custom_query {
             }
             $goodrow++;
             if ($perfname) {
-                $db->{perf} .= sprintf ' %s=%s;%s;%s',
-                    perfname($perfname), $r->{$perfname}, $warning, $critical;
+                if ($grandtotal > 1) {
+                    $db->{perf} = sprintf ' %s=%s;%s;%s',
+                        perfname($r->{$perfname}), $result, $warning, $critical;
+                } else {
+                    $db->{perf} .= sprintf ' %s=%s;%s;%s',
+                        perfname($perfname), $r->{$perfname}, $warning, $critical;
+                }
             }
             my $gotmatch = 0;
             if (! defined $result) {

--- a/check_postgres.pl
+++ b/check_postgres.pl
@@ -4404,6 +4404,7 @@ sub check_custom_query {
         ##   use the second column value as the perfdata name,
         ##   use the result value as the perfdata value.
         my $perfname;
+        my $perfdata;
         my $grandtotal = @{$db->{slurp}};
         for my $r (@{$db->{slurp}}) {
             my $result = $r->{result};
@@ -4418,8 +4419,11 @@ sub check_custom_query {
             $goodrow++;
             if ($perfname) {
                 if ($grandtotal > 1) {
-                    $db->{perf} = sprintf ' %s=%s;%s;%s',
+                    $perfdata = sprintf ' %s=%s;%s;%s',
                         perfname($r->{$perfname}), $result, $warning, $critical;
+                    if ($perfdata ne $db->{perf}){
+                        $db->{perf} .= $perfdata;
+                    }
                 } else {
                     $db->{perf} .= sprintf ' %s=%s;%s;%s',
                         perfname($perfname), $r->{$perfname}, $warning, $critical;


### PR DESCRIPTION
Allow `custom_query` checks with multiple rows of output to populate the second returned column as the perfdata variable name. Pass the result value as the perfdata value. Helpful for `count(*) GROUP BY` queries.

Example: alert when the count of any fruit is below 5. Output performance data for each fruit.
```
check_postgres.pl -H localhost --action custom_query --query="SELECT count(*) as result, name FROM fruit GROUP BY name" --valtype=integer --warn='5' --reverse
```

Current output without this change is not very useful: repeats the name of the 2nd column as the perfdata variable name, provides the name of each fruit as the perfdata value, but not the count. Repeats the threshold as the value.
```
POSTGRES_CUSTOM_QUERY WARNING: 5 | time=0.01s name=apple;5 name=orange;5; name=banana;5
```

With the change, trends in fruit counts can now be tracked over time in the performance data:
```
POSTGRES_CUSTOM_QUERY WARNING: 5 | time=0.01s apple=4;5 orange=12;5; banana;10;5
```