### PR TITLE
Support check_hot_standby_delay for PG10

### DIFF
--- a/check_postgres.pl
+++ b/check_postgres.pl
@@ -5111,7 +5111,12 @@ sub check_hot_standby_delay {
     my ($moffset, $s_rec_offset, $s_rep_offset, $time_delta);
 
     ## On slave
-    $SQL = q{SELECT pg_last_xlog_receive_location() AS receive, pg_last_xlog_replay_location() AS replay};
+    if ($version >= 10) {
+        $SQL = q{SELECT pg_last_wal_receive_lsn() AS receive, pg_last_wal_replay_lsn() AS replay};
+    }
+    else {
+        $SQL = q{SELECT pg_last_xlog_receive_location() AS receive, pg_last_xlog_replay_location() AS replay};
+    }
     if ($version >= 9.1) {
         $SQL .= q{, COALESCE(ROUND(EXTRACT(epoch FROM now() - pg_last_xact_replay_timestamp())),0) AS seconds};
     }
@@ -5141,7 +5146,12 @@ sub check_hot_standby_delay {
     }
 
     ## On master
-    $SQL = q{SELECT pg_current_xlog_location() AS location};
+    if ($version >= 10) {
+        $SQL = q{SELECT pg_current_wal_lsn() AS location};
+    }
+    else {
+        $SQL = q{SELECT pg_current_xlog_location() AS location};
+    }
     $info = run_command($SQL, { dbnumber => $master });
     for $db (@{$info->{db}}) {
         my $location = $db->{slurp}[0]{location};


### PR DESCRIPTION
Use renamed wal-functions according current [documentation](https://www.postgresql.org/docs/10/static/functions-admin.html).