### PR TITLE
#105 output per-database perfdata for pgbouncer pool checks (was |time=0.01 time=0.01 time=0.01 ...)

### DIFF
--- a/check_postgres.pl
+++ b/check_postgres.pl
@@ -1741,7 +1741,7 @@ sub add_response {
         $dbport;
     $header =~ s/\s+$//;
     $header =~ s/^ //;
-    my $perf = ($opt{showtime} and $db->{totaltime} and $action ne 'bloat') ? "time=$db->{totaltime}s" : '';
+    my $perf = ($opt{showtime} and $db->{totaltime} and $action ne 'bloat' and $action !~ /^pgb_pool_/ ) ? "time=$db->{totaltime}s" : '';
     if ($db->{perf}) {
         $db->{perf} =~ s/^ +//;
         if (length $same_schema_header) {
@@ -6259,6 +6259,7 @@ sub check_pgb_pool {
             $statsmsg{$i->{database}} = msg('pgbouncer-pool', $i->{database}, $stat, $i->{$stat});
             next;
         }
+        $db->{perf} = sprintf ' %s=%s;%s;%s', $i->{database}, $i->{$stat}, $warning, $critical;
 
         if ($critical and $i->{$stat} >= $critical) {
             add_critical $msg;


### PR DESCRIPTION
This pull request addresses issue #105 

It has the same objectives as the existing pull requests #104 and #76 
Sample output:

before:
```
> sudo -u pgbouncer check_postgres.pl -H /var/run/pgbouncer/ -p 6432 --action=pgb_pool_cl_active -u pgbouncer
POSTGRES_PGB_POOL_CL_ACTIVE OK: DB "pgbouncer" (host:/var/run/pgbouncer/) (port=6432) pgbouncer=1 * test_db1=2 * test_db2=1 | time=0.01s time=0.01s time=0.01s
```

after:
```
> sudo -u pgbouncer check_postgres.pl -H /var/run/pgbouncer/ -p 6432 --action=pgb_pool_cl_active -u pgbouncer
POSTGRES_PGB_POOL_CL_ACTIVE OK: DB "pgbouncer" (host:/var/run/pgbouncer/) (port=6432) pgbouncer=1 * test_db1=2 * test_db2=1 | pgbouncer=1; test_db1=2; test_db2=1;
```

Note that we lose the `time=...` performance statistic, but this represents the execution time for the query itself, and does not contribute to the actual performance being investigated.

When `pgb_pool_maxwait` is used, the maxwait time is provided per-database.
This is unrelated to the old `time=...` performance output, which was the same value repeated over the number of databases.
```
> sudo -u pgbouncer check_postgres.pl -H /var/run/pgbouncer/ -p 6432 --action=pgb_pool_maxwait -u pgbouncer
POSTGRES_PGB_POOL_MAXWAIT OK: DB "pgbouncer" (host:/var/run/pgbouncer/) (port=6432) pgbouncer=0 * test_db1=0 * test_db2=0 | pgbouncer=0; test_db1=0; test_db2=0;
```