### PR TITLE
query_time incorrectly filters out idle sessions on pg-9.3 (and possibly other versions)

### DIFF
--- a/check_postgres.pl
+++ b/check_postgres.pl
@@ -6707,7 +6707,7 @@ sub check_query_time {
                    msg('queries'),
                    msg('query-time'),
                    'query_start',
-                   q{query_start IS NOT NULL AND current_query NOT LIKE '<IDLE>%'});
+                   q{query_start IS NOT NULL AND state <> 'idle'});
 
     return;
 


### PR DESCRIPTION
The query for query time seems to incorrectly filter out idle queries.


I have a lot of queries like these (done at the time of this post)

```
  datid  |   datname   |  pid  | usesysid | usename  | application_name |  client_addr  | client_hostname | client_port |         backend_start         | xact_start |          query_start          |         state_change          | waiting | state |              query               
---------+-------------+-------+----------+----------+------------------+---------------+-----------------+-------------+------------------------------+------------+-------------------------------+-------------------------------+---------+-------+----------------------------------
 5012568 | cwportal_qa | 18740 |  5012567 | cwportal |                  | 10.117.196.52 |                 |       46238 | 2018-01-04 08:19:14.861928+01 |            | 2018-01-04 08:19:14.896908+01 | 2018-01-04 08:19:14.897035+01 | f       | idle  | SHOW TRANSACTION ISOLATION LEVEL
 5012568 | cwportal_qa | 29702 |  5012567 | cwportal |                  | 10.117.196.9  |                 |       54000 | 2017-12-21 21:15:29.969595+01 |            | 2017-12-21 21:15:30.207283+01 | 2017-12-21 21:15:30.207401+01 | f       | idle  | SET extra_float_digits = 3
 5012568 | cwportal_qa | 29703 |  5012567 | cwportal |                  | 10.117.196.9  |                 |       54012 | 2017-12-21 21:15:30.282938+01 |            | 2017-12-21 21:15:30.292606+01 | 2017-12-21 21:15:30.292688+01 | f       | idle  | SET extra_float_digits = 3
 5012568 | cwportal_qa | 29704 |  5012567 | cwportal |                  | 10.117.196.9  |                 |       54016 | 2017-12-21 21:15:30.297895+01 |            | 2017-12-21 21:15:30.30705+01  | 2017-12-21 21:15:30.307138+01 | f       | idle  | SET extra_float_digits = 3
 5012568 | cwportal_qa | 29705 |  5012567 | cwportal |                  | 10.117.196.9  |                 |       54018 | 2017-12-21 21:15:30.312506+01 |            | 2017-12-21 21:15:30.322079+01 | 2017-12-21 21:15:30.322167+01 | f       | idle  | SET extra_float_digits = 3
 5012568 | cwportal_qa | 29706 |  5012567 | cwportal |                  | 10.117.196.9  |                 |       54020 | 2017-12-21 21:15:30.32812+01  |            | 2017-12-21 21:15:30.337675+01 | 2017-12-21 21:15:30.337799+01 | f       | idle  | SET extra_float_digits = 3
 5012568 | cwportal_qa | 29707 |  5012567 | cwportal |                  | 10.117.196.9  |                 |       54022 | 2017-12-21 21:15:30.343397+01 |            | 2017-12-21 21:15:30.352818+01 | 2017-12-21 21:15:30.3529+01   | f       | idle  | SET extra_float_digits = 3

```

And the current filter does not exclude them, causing check to print that i have queries running for multiple days, even though i have none.

This is on postgresql-9.3
  