### PR TITLE
check_disk_space: handle relative symlinks for the WAL directory

### DIFF
--- a/check_postgres.pl
+++ b/check_postgres.pl
@@ -26,6 +26,7 @@ use File::Spec;
 use File::Temp qw/tempfile tempdir/;
 File::Temp->safe_level( File::Temp::MEDIUM );
 use Cwd;
+use Cwd 'abs_path';
 use Data::Dumper qw/Dumper/;
 $Data::Dumper::Varname = 'POSTGRES';
 $Data::Dumper::Indent = 2;
@@ -4995,6 +4996,12 @@ WHERE spclocation <> ''
             my $xlog = "$datadir/pg_xlog";
             if (-l $xlog) {
                 my $linkdir = readlink($xlog);
+
+                ## Handle relative symbolic links
+                if ($linkdir =~ m|^\.|) {
+                    $linkdir = abs_path("$datadir/$linkdir");
+                }
+
                 $dir{$linkdir} = 1 if ! exists $dir{$linkdir};
             }
         }


### PR DESCRIPTION
If the WAL directory (pg_xlog or pg_wal) resolves to a symbolic link,
e.g. "../some-wal-dir", the check fails with an error like:

    ERROR: Invalid result from command "/bin/df -kP "../some-wal-dir" 2>&1": /bin/df: "../some-wal-dir": No such file or directory

This patch checks for a relative symlink and extracts the actual WAL directory
using abs_path().

Not sure if it's feasible to add a test for this, if it is please let me know.