### PR TITLE
fix run_command() to handle passed versions correctly

### DIFF
--- a/check_postgres.pl
+++ b/check_postgres.pl
@@ -2874,11 +2874,9 @@ sub run_command {
                     my ($mod,$ver) = ($1||'',$2);
                     if ($mod eq '>' and $db->{version} > $ver) {
                         $string = $row;
-                        last;
                     }
                     if ($mod eq '<' and $db->{version} < $ver) {
                         $string = $row;
-                        last;
                     }
                     if ($mod eq '' and $db->{version} eq $ver) {
                         $string = $row;


### PR DESCRIPTION
check_txn_idle() introduced multiple '>' version ckecks to handle v10 postgres, but run_command() does not correctly implement such multiple '>' or '<' version checks.

run_command() should match the highest '<' or '>' version.

The modified implementation works if and only if the versions are
passed in ascending order, which is the way check_txn_idle() currently passes them.