### PR TITLE
make work with multiple slots

### DIFF
--- a/check_postgres.pl
+++ b/check_postgres.pl
@@ -5500,11 +5500,19 @@ sub check_replication_slots {
     $SQL = qq{
         WITH slots AS (SELECT slot_name,
             slot_type,
-            coalesce(restart_lsn, '0/0'::pg_lsn) AS slot_lsn,
-            coalesce(pg_xlog_location_diff(coalesce(pg_last_xlog_receive_location(), pg_current_xlog_location()), restart_lsn),0) AS delta,
+            COALESCE(restart_lsn, '0/0'::pg_lsn) AS slot_lsn,
+            COALESCE(pg_xlog_location_diff(
+                CASE
+                    WHEN pg_is_in_recovery() THEN
+                        pg_last_xlog_receive_location()
+                    ELSE
+                        pg_current_xlog_location()
+                END,
+                restart_lsn
+            ), 0) AS delta,
             active
         FROM pg_replication_slots)
-        SELECT *, pg_size_pretty(delta) AS delta_pretty FROM slots;
+        SELECT *, pg_size_pretty(delta) AS delta_pretty FROM slots
     };
 
     if ($opt{perflimit}) {
@@ -5518,27 +5526,39 @@ sub check_replication_slots {
     my $found = 0;
 
     for $db (@{$info->{db}}) {
-        my $max = -1;
+        my $max = 0;
+        my $total = 0;
         $found = 1;
         my %s;
 
         for my $r (@{$db->{slurp}}) {
-            if (skip_item($r->{slot_name})) {
-                $max = -2 if ($max == -1 );
-                next;
-            }
-            if ($r->{delta} >= $max) {
-                $max = $r->{delta};
-            }
+            # keep track of how many slots that we found
+            ++$total;
+
+            # apply exclusion rules
+            next if skip_item($r->{slot_name});
+
+            # keep track of the largest backlog
+            $max = $r->{delta} if ($r->{delta} >= $max);
+
+            # keep track of all slots
             $s{$r->{slot_name}} = [$r->{delta},$r->{delta_pretty},$r->{slot_type},$r->{slot_lsn},$r->{active}];
         }
+
+        # record how far back our farthest back slot is
         if ($MRTG) {
-            do_mrtg({one => $max, msg => "SLOT: $db->{slot_name}"});
+            do_mrtg({one => $max, msg => "DB: $db->{dbname}"});
         }
-        if ($max < 0) {
+
+        if (!scalar(keys(%s))) {
             $stats{$db->{dbname}} = 0;
-            add_ok msg('no-match-slotok') if ($max == -1);
-            add_unknown msg('no-match-slot') if ($max == -2);
+            if ($total > 0) {
+                # found slots but they didn't match
+                add_ok msg('no-match-slot');
+            } else {
+                # found no slots
+                add_ok msg('no-match-slotok');
+            }
             next;
         }
 


### PR DESCRIPTION
Sorry to do another pull request on this, especially since this one is slightly more disruptive. I just discovered a number of problems while trying to monitor more of our stuff. I also discovered that my original pull request didn't quite solve the problem that I was trying to solve. This corrects a few problems:

1. The query itself was computing values backwards and generating negative differences in all cases. Also, the coalesce that I submitted yesterday was too simplistic and ended up returning incorrect values in some cases. This query will return correct values that I've tested against multiple clusters that I currently run including against a cluster that has multiple active and inactive replication slots.

2. Line 5536/5550, there is no value in `$db->{slot_name}` ever. It is never assigned. I'm fairly certain that what is intended is to record the maximum backlog on the database across all slots so that's what it does now.

3. Line 5541/5560, when no slots match the exclusion rules it should still be OK and not UNKNOWN.

4. In general, `$max` should contain the maximum number of bytes that a slot is causing the database to retain. In this original code `$max` was also being used to store the results of the check (were slots skipped? set to `-2` I guess?). Because the query was generating negative differences the check on line 5530 would never pass because `$r->{delta}` would never be greater than `-1` (or `-2`) because it was always negative. So basically this check would never fail and definitely didn't work when multiple slots existed.

The tests for this (in 02_replication_slots.t) continue to pass with these changes but I'm not 100% sure that they were good or exhaustive tests to begin with. I don't have a good example in the existing tests of how to test replication between multiple servers in the tests so if you have pointers on where to start writing those tests then I'd be happy to write some.