### PR TITLE
check_disk_space: handle relative log_directory path

### DIFF
--- a/check_postgres.pl
+++ b/check_postgres.pl
@@ -5223,7 +5223,7 @@ WHERE spclocation <> ''
 
         ## Check log_directory: relative or absolute
         if (length $logdir) {
-            if ($logdir =~ /^\w/) { ## relative, check only if symlinked
+            if ($logdir =~ /^[\w\.]/) { ## relative, check only if symlinked
                 $logdir = "$datadir/$logdir";
                 if (-l $logdir) {
                     my $linkdir = readlink($logdir);


### PR DESCRIPTION
If the log_directory resolves to a relative path,
e.g. "../pg_log", the check_disk_space fails with an error like:

ERROR: Invalid result from command "/bin/df -kP "../pg_log" 2>&1": /bin/df: â: No such file or directory

This patch adds a verification to check if the logdir variable starts with a .[dot]