### PR TITLE
align check_wal_files() code with it's test case

### DIFF
--- a/check_postgres.pl
+++ b/check_postgres.pl
@@ -9042,10 +9042,10 @@ sub check_wal_files {
             : msg('wal-numfound', $numfiles);
         $db->{perf} .= sprintf '%s=%s;%s;%s',
             perfname(msg('files')), $numfiles, $warning, $critical;
-        if (length $critical and $numfiles > $critical) {
+        if (length $critical and $numfiles >= $critical) {
             add_critical $msg;
         }
-        elsif (length $warning and $numfiles > $warning) {
+        elsif (length $warning and $numfiles >= $warning) {
             add_warning $msg;
         }
         else {


### PR DESCRIPTION
Test 02_wal_files.t may fail against a newly created (by the framework
in CP_Testing.pm) database (PostgreSQL 13) with

:   Failed test 'Action 'wal_files' works as expected for warnings'
:   at t/02_wal_files.t line 44.
:                   'POSTGRES_WAL_FILES OK: DB "postgres" (host:/tmp/cptesting_socket) WAL files found: 1 | time=0.01s files=1;1
: '
:     doesn't match '(?^:^POSTGRES_WAL_FILES WARNING)'

as there is exactly one WAL file and the test expects the check to raise
warning/critical alerts at one WAL file - just as the documentation of
the alert levels says "the threshold at wich a warning/critical alert is
fired", but the code in check_wal_files() checks if the number of files
is _greater_ than the alerting threshold. Admitted that this is a corner
case, but it is annoying af when running the tests.
Fix by converting the greater '>' into 'greater-or-equal' '>=' checks.