### PR TITLE
ensure PostgreSQL log_destination is set to 'stderr'

### DIFF
--- a/t/CP_Testing.pm
+++ b/t/CP_Testing.pm
@@ -155,6 +155,7 @@ sub _test_database_handle {
         print $cfh qq{listen_addresses = ''\n};
         print $cfh qq{max_connections = 10\n};
         print $cfh qq{fsync = off\n};
+        print $cfh qq{log_destination = 'stderr'\n};
 
         ## <= 8.0
         if ($imaj < 8 or (8 == $imaj and $imin <= 1)) {


### PR DESCRIPTION
Some packages - I'm looking at FreeBSD here:
  https://github.com/freebsd/freebsd-ports/blob/main/databases/postgresql14-server/files/patch-src_backend_utils_misc_postgresql.conf.sample
set log_destination to a non-standard value in the postgresql.conf
template. CP_Testing.pm relies on the log output to detect server
start and is defeated by this packaging.
Instead of arguing with package maintainers, just force-set
log_destination to 'stderr' and have CP_Testing.pm do it's work.