### PR TITLE
add user to pgb pool output (check_pgb_pool)

### DIFF
--- a/check_postgres.pl
+++ b/check_postgres.pl
@@ -6756,7 +6756,7 @@ sub check_pgb_pool {
     my $gotone = 0;
     for my $i (@$output) {
         next if skip_item($i->{database});
-        my $msg = "$i->{database}=$i->{$stat}";
+        my $msg = "$i->{user}\@$i->{database}=$i->{$stat}";
 
         if ($MRTG) {
             $stats{$i->{database}} = $i->{$stat};


### PR DESCRIPTION
Since a pgBouncer pool is tied to a user+database pair, the previous
output was less useful with large numbers of users in a single database.

Adding the user to the output makes it clear which pool is associated
with which value.

The new output looks something like:

```
POSTGRES_PGB_POOL_CL_WAITING OK: DB "pgbouncer" (host:dbserver) (port=5432) django_web@django=0 * django_admin@django=0 django_reporting@django=0 * websiteuser@bigdatabase=0 * user1@bigdatabase=0 *user2@bigdatabase=0 * user3@bigdatabase=0 * badly_behaved_user@bigdatabase=3 | time=0.02s time=0.02s time=0.02s time=0.02s time=0.02s time=0.02s time=0.02s
```