### PR TITLE
Fix typo in documentation

### DIFF
--- a/check_postgres.pl.html
+++ b/check_postgres.pl.html
@@ -2,7 +2,7 @@
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml">
 <head>
-<title>check_postgres.pl>
+<title>check_postgres.pl</title>
 <meta http-equiv="content-type" content="text/html; charset=utf-8" />
 
 </head>


### PR DESCRIPTION
Add closing `<title>` tag