### PR TITLE
Disable .psqlrc when fetching list of databases (alldb option) -  Fixes #207

### DIFF
--- a/check_postgres.pl
+++ b/check_postgres.pl
@@ -2126,7 +2126,7 @@ if (defined $opt{alldb}){
     if ($opt{port}[0]){
         $pg_port = $opt{port}[0];
     }
-    my $psql_output = join(",", map /^([\w|-]+?)\|/, qx{$PSQL -A -l -t -p $pg_port });
+    my $psql_output = join(",", map /^([\w|-]+?)\|/, qx{$PSQL -A -l -t -X -p $pg_port });
     my $pg_db;
     # optionally exclude or include each db
     my @psql_output_array = split(/,/, $psql_output);


### PR DESCRIPTION
When using alldb option in presence of (some) .psqlrc, fetching list of databases failed.
This PR disable .psqlrc by adding -X option.