### PR TITLE
Add defaultuser / dbuser for --alldb option

### DIFF
--- a/check_postgres.pl
+++ b/check_postgres.pl
@@ -2126,7 +2126,11 @@ if (defined $opt{alldb}){
     if ($opt{port}[0]){
         $pg_port = $opt{port}[0];
     }
-    my $psql_output = join(",", map /^([\w|-]+?)\|/, qx{$PSQL -A -l -t -p $pg_port });
+    my $pg_user = $opt{defaultuser};
+    if ($opt{dbuser}[0]){
+        $pg_user = $opt{dbuser}[0];
+    }
+    my $psql_output = join(",", map /^([\w|-]+?)\|/, qx{$PSQL -U $pg_user -A -l -t -p $pg_port });
     my $pg_db;
     # optionally exclude or include each db
     my @psql_output_array = split(/,/, $psql_output);


### PR DESCRIPTION
Currently the --alldb option doesnt use the defaultuser / dbuser for psql, so an error is returned when the os user who started the script doesnt have acces to postgres.